### PR TITLE
Utilites.safeWrite's business logic fixed

### DIFF
--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -181,7 +181,7 @@ class Model {
       redisKey = `${this.keyPrefix}:${redisKey}`;
     }
 
-    return await safeWrite(data, redisKey, this.redisClient, this.flexSchema, this.schema);
+    return await safeWrite(data, redisKey, this.redisClient, this.schema, this.flexSchema);
   }
 
   /**

--- a/lib/ModelInstance.ts
+++ b/lib/ModelInstance.ts
@@ -31,7 +31,7 @@ class ModelInstance {
   public async save(): Promise<void> {
     const { _Model, ...data } = this;
     const { redisClient, flexSchema, schema } = _Model._model;
-    await safeWrite(data, _Model._dataInfo.redisKey, redisClient, flexSchema, schema);
+    await safeWrite(data, _Model._dataInfo.redisKey, redisClient, schema, flexSchema);
   }
 
   public getPureData(): Object {

--- a/lib/utility.ts
+++ b/lib/utility.ts
@@ -77,18 +77,16 @@ export const safeRead = async (
  * @param schema - Model schema
  */
 export const safeWrite = async (
-  data: Object,
+  data: { [key: string | number]: any } ,
   redisKey: String,
   redisClient: any,
-  isFlex: Boolean = false,
   schema: Object = {},
+  isFlex: Boolean | null = false, 
 ): Promise<Object> => {
   if (!isFlex) { // if isFlex is falsy, you can only save fields inside the schema
-    const temp: { [key: string]: any } = schema;
-    Object.entries(data).forEach(([key, value]) => {
-      if (temp[key]) {
-        temp[key] = value;
-      }
+    const temp: { [key: string]: any } = {};
+    Object.entries(schema).forEach(([key, value]) => { // data: { a, b, c } | schema: { b, c, d } ==> temp: { b, c, d}
+      temp[key] = data[key] || value; 
     });
     data = temp;
   }


### PR DESCRIPTION
`ModelInstance.save` fonksiyonundaki hata yüzünden kullanıcılarda `Model.isFlex` değeri `false` yani şemadaki alanların dışına çıkılamadığı kayıtlarda bazı değerler kaydedilecek kayıtta olduğu halde içine şemadaki varsayılan değerler yazılıyordu.

Yaptığım inceleme sonucunda hatanın şema değerlerini atayan ve objeleri kaydederken JSON'a çeviren `safeWrite`  fonksiyonu içinde buldum. Fonksiyon yazılırken mantıksal bir hata yapılmış ve gelen veri içindeki bazı değerlerin ezilmesi daha da önemlisi şemanın istenmeyen bir şekilde değiştirilmesi mümkün hale getirilmiş.

Şema ile yapılan atama işlemlerini tamamen ortadan kaldırarak şema kullanımını daha güvenli hale getirdim. İleriki süreçte daha güvenli olması için şema tamamen `readonly` hale getirlimelidir. Kod içinde mantıksal değişiklik de yaparak fonksiyonu düzgün çalışır hale getirdim.

## Kod Çıktısı
Model'in `isFlex` değeri `false` olduğu için  gelen veri içindeki sadece şemada bulunan alanlar ayıklanmalı eğer bir key şemada var fakat gelen veride yoksa şemadaki varsayılan değeri otomatik olarak atanmalıdır.
 
`data` değişkeni gelen veriyi, `schema` değişkeni şemayı ve temp ise çıktıyı temsil etmektedir.
![Screenshot_20220709_023210](https://user-images.githubusercontent.com/56413673/178082383-1a538907-e48c-4c6d-bcd1-e2a07e629ba7.png)

Bu yapıya göre `b` ve `c` keyleri ortaktır ve `d` şemada olduğu için çıktıya eklenmelidir. 

**Eski mantıksal işleyişe göre:**
`temp=schema` atamasından dolayı şemanın da değeri değişmekteydi.
![Screenshot_20220709_023746](https://user-images.githubusercontent.com/56413673/178082413-1eb32807-dbed-47c2-aca4-6b35df71fc66.png)
**Yeni mantıksal işleyişe göre:**

![Screenshot_20220709_023553](https://user-images.githubusercontent.com/56413673/178082502-5591d5a9-34dc-40fb-9766-d1e346ad765a.png)

Close #27 


